### PR TITLE
Fix root domain name parsing

### DIFF
--- a/packet.js
+++ b/packet.js
@@ -65,6 +65,9 @@ function nameUnpack(buff) {
   len = buff.readUInt8();
   comp = false;
 
+  // A null byte at the start of a name indicates the root domain name
+  if (len === 0) end = buff.tell();
+
   while (len !== 0) {
     if (isPointer(len)) {
       len -= LABEL_POINTER;
@@ -607,7 +610,7 @@ var
   PARSE_NAPTR = consts.NAME_TO_QTYPE.NAPTR,
   PARSE_OPT   = consts.NAME_TO_QTYPE.OPT,
   PARSE_SPF   = consts.NAME_TO_QTYPE.SPF;
-  
+
 
 Packet.parse = function(msg) {
   var state,


### PR DESCRIPTION
This fixes a query for the root zone (issued from [`native-dns`](https://github.com/tjfontaine/node-dns)), like this:

``` js
var question = dns.Question({
    name: "",
    type: "NS",
});
```

Previously, the returning packet to this query could not be parsed and `native-dns` never received the packet and ran into a timeout.

From [RFC 1035](https://www.ietf.org/rfc/rfc1035.txt): The root domain name is defined by a single octet of zeros at 92; the root domain name has no labels.
