### PR TITLE
Fix #26: rcode bitmask should be 5 bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+Daplie is Taking Back the Internet!
+--------------
+
+[![](https://daplie.github.com/igg/images/ad-developer-rpi-white-890x275.jpg?v2)](https://daplie.com/preorder/)
+
+Stop serving the empire and join the rebel alliance!
+
+* [Invest in Daplie on Wefunder](https://daplie.com/invest/)
+* [Pre-order Cloud](https://daplie.com/preorder/), The World's First Home Server for Everyone
+
 native-dns-packet
 -----------------
 

--- a/packet.js
+++ b/packet.js
@@ -167,7 +167,7 @@ function writeHeader(buff, packet) {
   val += (packet.header.res1 << 6) & 0x40;
   val += (packet.header.res2 << 5) & 0x20;
   val += (packet.header.res3 << 4) & 0x10;
-  val += packet.header.rcode & 0xF;
+  val += packet.header.rcode & 0x1F;
   buff.writeUInt16BE(val & 0xFFFF);
   assert(packet.question.length == 1, 'DNS requires one question');
   // aren't used


### PR DESCRIPTION
Fix #26:

From 0xF (4 bits) to 0x1F (5 bits, <= 31)

At the very least it doesn't seem to break anything.
