### PR TITLE
Fix #26: rcode bitmask should be 5 bits

### DIFF
--- a/packet.js
+++ b/packet.js
@@ -167,7 +167,7 @@ function writeHeader(buff, packet) {
   val += (packet.header.res1 << 6) & 0x40;
   val += (packet.header.res2 << 5) & 0x20;
   val += (packet.header.res3 << 4) & 0x10;
-  val += packet.header.rcode & 0xF;
+  val += packet.header.rcode & 0x1F;
   buff.writeUInt16BE(val & 0xFFFF);
   assert(packet.question.length == 1, 'DNS requires one question');
   // aren't used


### PR DESCRIPTION
From 0xF (4 bits) to 0x1F (5 bits, <= 31) (fixes #26)


In relation to https://github.com/tjfontaine/native-dns-packet/pull/27 which was closed because I accidentally pushed some local-fork changes to the same branch that was in the patch.